### PR TITLE
skip file rather than exit when a yaml file with no melange package n…

### DIFF
--- a/pkg/graph.go
+++ b/pkg/graph.go
@@ -59,7 +59,8 @@ func NewGraph(dirFS fs.FS) (*Graph, error) {
 			}
 			name := c.Package.Name
 			if name == "" {
-				log.Fatalf("no package name in %q", path)
+				log.Printf("no package name in %q", path)
+				return nil
 			}
 			if _, exists := configs[name]; exists {
 				log.Fatalf("duplicate package config found for %q in %q", c.Package, path)


### PR DESCRIPTION
…ame found

noticed this when running dag in a folder that had other yaml files which were not melange configs, so wanted dag to ignore these files.

Signed-off-by: James Rawlings <jrawlings@chainguard.dev>