### PR TITLE
wait for daemonsets to become ready

### DIFF
--- a/scripts/setup-cluster.sh
+++ b/scripts/setup-cluster.sh
@@ -32,6 +32,10 @@ kubectl patch daemonset csi-secrets-store \
   -n kube-system \
   --patch-file=arm-patch-2.yaml
 
+# Wait for DaemonSets to become ready.
+kubectl rollout status daemonset -n kube-system csi-secrets-store
+kubectl rollout status daemonset -n kube-system csi-secrets-store-provider-gcp
+
 # Bind the melange signing key GCP secret to the secrets store CSI driver.
 cat <<EOF | kubectl apply -f -
 apiVersion: secrets-store.csi.x-k8s.io/v1


### PR DESCRIPTION
Without this the call to `dag pod` might spend some of its five-minutes-to-become-ready timeout waiting for the daemonset to become ready, when it should really be ready before `dag pod` is involved.