### PR TITLE
pod: dont use ephemeral storage for melange operations

### DIFF
--- a/pkg/commands/pod.go
+++ b/pkg/commands/pod.go
@@ -137,6 +137,9 @@ func cmdPod() *cobra.Command {
 						}, {
 							Name:      "cache",
 							MountPath: "/var/cache/melange",
+						}, {
+							Name:      "tmp",
+							MountPath: "/tmp",
 						}},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged: pointer.Bool(true),
@@ -179,6 +182,11 @@ exit 0`, strings.Join(targets, " ")),
 						},
 					}, {
 						Name: "cache",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
+						},
+					}, {
+						Name: "tmp",
 						VolumeSource: corev1.VolumeSource{
 							EmptyDir: &corev1.EmptyDirVolumeSource{},
 						},


### PR DESCRIPTION
using ephemeral storage for melange operations can cause containerd to freeze up when there is heavy iowait from snapshotting operations, which then causes the build node systemd to kill containerd which causes the kubelet to fail which causes the build to fail.