### PR TITLE
pod: use bash to fetch packages

### DIFF
--- a/pkg/commands/pod.go
+++ b/pkg/commands/pod.go
@@ -138,8 +138,7 @@ func cmdPod() *cobra.Command {
 							Name:      "workspace",
 							MountPath: "/workspace",
 						}},
-						Command: []string{
-							"sh", "-c", `
+						Command: []string{"bash", "-c", `
 set -euo pipefail
 # Download all packages so we can avoid rebuilding them.
 mkdir -p ./packages/
@@ -172,9 +171,7 @@ find ./packages -print -exec touch \{} \;
 						SecurityContext: &corev1.SecurityContext{
 							Privileged: pointer.Bool(true),
 						},
-						Command: []string{
-							"sh", "-c",
-							fmt.Sprintf(`
+						Command: []string{"sh", "-c", fmt.Sprintf(`
 set -euo pipefail
 ls /var/cache/melange
 if [[ ! -f /var/secrets/melange.rsa ]]; then


### PR DESCRIPTION
```
$ docker run --rm -it gcr.io/google.com/cloudsdktool/google-cloud-cli:slim sh -c "set -euo pipefail; echo hello"
sh: 1: set: Illegal option -o pipefail
```

```
$ docker run --rm -it gcr.io/google.com/cloudsdktool/google-cloud-cli:slim bash -c "set -euo pipefail; echo hello"
hello
```

This failure was seen in https://github.com/wolfi-dev/os/actions/runs/3735090889/jobs/6338442859