### PR TITLE
pod: fix packages path to include arch

### DIFF
--- a/pkg/commands/pod.go
+++ b/pkg/commands/pod.go
@@ -142,9 +142,9 @@ func cmdPod() *cobra.Command {
 						Command: []string{"bash", "-c", fmt.Sprintf(`
 set -euo pipefail
 # Download all packages so we can avoid rebuilding them.
-mkdir -p ./packages/
-gsutil -m rsync -r %s%s ./packages/ || true
-`, srcBucket, arch)},
+mkdir -p ./packages/%s
+gsutil -m rsync -r %s%s ./packages/%s || true
+`, arch, srcBucket, arch, arch)},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								// Minimums required by Autopilot.


### PR DESCRIPTION
In addition to fixing a bug, https://github.com/wolfi-dev/dag/pull/33 "helpfully" reduced the number of packages we'd sync from the bucket of build packages, so it only fetched those matching the arch we're about to build.

Unfortunately it also messed up the path where those packages would be placed locally, so that `make all` would always rebuild every package from scratch.

This was discovered because `etcd` failed to build; `etcd` just seems to be the first entry in Makefile that doesn't have all of its dependencies listed previously in the Makefile (it needs `busybox`, `wget`, etc., all listed later).

Signed-off-by: Jason Hall <jason@chainguard.dev>