### PR TITLE
text: emit make commands or makefile lines

### DIFF
--- a/pkg/commands/text.go
+++ b/pkg/commands/text.go
@@ -6,21 +6,20 @@ import (
 	"log"
 	"os"
 
+	"chainguard.dev/apko/pkg/build/types"
 	"github.com/dominikbraun/graph"
 	"github.com/spf13/cobra"
 	"github.com/wolfi-dev/dag/pkg"
 )
 
 func cmdText() *cobra.Command {
-	var dir, arch string
+	var dir, arch, t string
 	var showDependents bool
 	text := &cobra.Command{
 		Use:   "text",
 		Short: "Print a sorted list of downstream dependent packages",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if arch == "arm64" {
-				arch = "aarch64"
-			}
+			arch := types.ParseArchitecture(arch).ToAPK()
 
 			g, err := pkg.NewGraph(os.DirFS(dir), dir)
 			if err != nil {
@@ -58,33 +57,56 @@ func cmdText() *cobra.Command {
 				g = subgraph
 			}
 
-			err = text(*g, arch, os.Stdout)
-			if err != nil {
-				return err
-			}
-
-			return nil
+			return text(*g, arch, textType(t), os.Stdout)
 		},
 	}
 	text.Flags().StringVarP(&dir, "dir", "d", ".", "directory to search for melange configs")
 	text.Flags().StringVarP(&arch, "arch", "a", "x86_64", "architecture to build for")
 	text.Flags().BoolVarP(&showDependents, "show-dependents", "D", false, "show packages that depend on these packages, instead of these packages' dependencies")
+	text.Flags().StringVarP(&t, "type", "t", string(typeTarget), "What type of text to emit")
 	return text
 }
 
-func text(g pkg.Graph, arch string, w io.Writer) error {
+type textType string
+
+const (
+	typeTarget       = "target"
+	typeMakefileLine = "makefile"
+)
+
+func reverse(ss []string) {
+	last := len(ss) - 1
+	for i := 0; i < len(ss)/2; i++ {
+		ss[i], ss[last-i] = ss[last-i], ss[i]
+	}
+}
+
+func text(g pkg.Graph, arch string, t textType, w io.Writer) error {
 	all, err := g.Sorted()
 	if err != nil {
 		return err
 	}
+	reverse(all)
 
 	for _, node := range all {
-		target, err := g.MakeTarget(node, arch)
-		if err != nil {
-			return err
+		switch t {
+		case typeTarget:
+			target, err := g.MakeTarget(node, arch)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(w, "%s\n", target)
+		case typeMakefileLine:
+			entry, err := g.MakefileEntry(node)
+			if err != nil {
+				return err
+			}
+			if entry != "" {
+				fmt.Fprintf(w, "%s\n", entry)
+			}
+		default:
+			return fmt.Errorf("invalid type: %s", t)
 		}
-
-		fmt.Fprintf(w, "%s\n", target)
 	}
 
 	return nil

--- a/pkg/commands/text.go
+++ b/pkg/commands/text.go
@@ -70,8 +70,8 @@ func cmdText() *cobra.Command {
 type textType string
 
 const (
-	typeTarget       = "target"
-	typeMakefileLine = "makefile"
+	typeTarget       textType = "target"
+	typeMakefileLine textType = "makefile"
 )
 
 func reverse(ss []string) {
@@ -95,7 +95,9 @@ func text(g pkg.Graph, arch string, t textType, w io.Writer) error {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(w, "%s\n", target)
+			if target != "" {
+				fmt.Fprintf(w, "%s\n", target)
+			}
 		case typeMakefileLine:
 			entry, err := g.MakefileEntry(node)
 			if err != nil {

--- a/pkg/graph.go
+++ b/pkg/graph.go
@@ -57,8 +57,7 @@ func NewGraph(dirFS fs.FS, dirPath string) (*Graph, error) {
 			}
 
 			c := build.Configuration{}
-			err = (&c).Load(*buildContext)
-			if err != nil {
+			if err := (&c).Load(*buildContext); err != nil {
 				return err
 			}
 
@@ -66,12 +65,28 @@ func NewGraph(dirFS fs.FS, dirPath string) (*Graph, error) {
 			if name == "" {
 				log.Fatalf("no package name in %q", path)
 			}
-			if _, exists := configs[name]; exists {
+			if p, exists := configs[name]; exists && !strings.HasPrefix(p.Package.Description, "PROVIDED BY") {
 				log.Fatalf("duplicate package config found for %q in %q", c.Package.Name, path)
 			}
 
 			configs[name] = c
 			packages = append(packages, name)
+
+			for _, prov := range c.Package.Dependencies.Provides {
+				p, v, ok := strings.Cut(prov, "=")
+				if !ok {
+					log.Fatalf("don't know how to interpret %q in %s", prov, path)
+				}
+				if _, exists := configs[p]; !exists {
+					configs[p] = build.Configuration{
+						Package: build.Package{
+							Name:        p,
+							Version:     v,
+							Description: fmt.Sprintf("PROVIDED BY %s", c.Package.Name),
+						},
+					}
+				}
+			}
 
 			g.AddVertex(name)
 		}
@@ -124,12 +139,10 @@ func NewGraph(dirFS fs.FS, dirPath string) (*Graph, error) {
 			if buildDep == "" {
 				log.Fatalf("empty package name in environment packages for %q", c.Package.Name)
 			}
-			err = g.AddVertex(buildDep)
-			if err != nil {
+			if err := g.AddVertex(buildDep); err != nil {
 				return nil, fmt.Errorf("unable to add vertex for %q dependency %q: %w", name, buildDep, err)
 			}
-			err = g.AddEdge(c.Package.Name, buildDep)
-			if err != nil {
+			if err := g.AddEdge(c.Package.Name, buildDep); err != nil {
 				if isErrCycle(err) {
 					log.Printf("warning: package %q depedendency on %q would introduce a cycle, so %q needs to be provided via bootstrapping", name, buildDep, buildDep)
 				} else {
@@ -168,30 +181,11 @@ func (g Graph) Config(name string) *build.Configuration {
 	return nil
 }
 
-// IsSubpackage returns a bool indicating whether the package with the given name
-// is a subpackage. If the package is an origin package, or if the package is not
-// found in the graph, IsSubpackage returns false.
-func (g Graph) IsSubpackage(name string) bool {
-	c := g.Config(name)
-
-	if c == nil {
-		// This (sub)package doesn't exist in the graph.
-		return false
-	}
-
-	return c.Package.Name != name
-}
-
 // Sorted returns a list of all package names in the Graph, sorted in topological
 // order, meaning that packages earlier in the list depend on packages later in
 // the list.
 func (g Graph) Sorted() ([]string, error) {
-	sorted, err := graph.TopologicalSort(g.Graph)
-	if err != nil {
-		return nil, err
-	}
-
-	return sorted, nil
+	return graph.TopologicalSort(g.Graph)
 }
 
 // SubgraphWithRoots returns a new Graph that's a subgraph of g, where the set of
@@ -294,7 +288,18 @@ func (g Graph) MakeTarget(pkgName, arch string) (string, error) {
 	p := config.Package
 
 	// note: using pkgName here because it may be a subpackage, not the main package declared within the config (i.e. `p.Name`)
-	return fmt.Sprintf("packages/%s/%s-%s-r%d.apk", arch, pkgName, p.Version, p.Epoch), nil
+	return fmt.Sprintf("make packages/%s/%s-%s-r%d.apk", arch, pkgName, p.Version, p.Epoch), nil
+}
+
+func (g Graph) MakefileEntry(pkgName string) (string, error) {
+	config := g.Config(pkgName)
+	if config == nil {
+		return "", fmt.Errorf("unable to generate target: no config for package %q", pkgName)
+	}
+	if pkgName != config.Package.Name {
+		return "", nil
+	}
+	return fmt.Sprintf("$(eval $(call build-package,%s,%s-%d))", pkgName, config.Package.Version, config.Package.Epoch), nil
 }
 
 // Nodes returns a slice of the names of all nodes in the Graph, sorted alphabetically.

--- a/pkg/graph.go
+++ b/pkg/graph.go
@@ -51,13 +51,8 @@ func NewGraph(dirFS fs.FS, dirPath string) (*Graph, error) {
 			defer f.Close()
 
 			p := filepath.Join(dirPath, path)
-			buildContext, err := build.New(build.WithConfig(p))
+			c, err := build.ParseConfiguration(p)
 			if err != nil {
-				return err
-			}
-
-			c := build.Configuration{}
-			if err := (&c).Load(*buildContext); err != nil {
 				return err
 			}
 
@@ -69,7 +64,7 @@ func NewGraph(dirFS fs.FS, dirPath string) (*Graph, error) {
 				log.Fatalf("duplicate package config found for %q in %q", c.Package.Name, path)
 			}
 
-			configs[name] = c
+			configs[name] = *c
 			packages = append(packages, name)
 
 			for _, prov := range c.Package.Dependencies.Provides {

--- a/pkg/graph.go
+++ b/pkg/graph.go
@@ -279,6 +279,9 @@ func (g Graph) MakeTarget(pkgName, arch string) (string, error) {
 	if config == nil {
 		return "", fmt.Errorf("unable to generate target: no config for package %q", pkgName)
 	}
+	if pkgName != config.Package.Name {
+		return "", nil
+	}
 
 	p := config.Package
 


### PR DESCRIPTION
Signed-off-by: Jason Hall <jason@chainguard.dev>

```
$ dag text
make packages/x86_64/wolfi-baselayout-20221118-r0.apk
make packages/x86_64/wget-1.21.3-r2.apk
make packages/x86_64/xz-5.4.0-r0.apk
make packages/x86_64/pax-utils-1.3.4-r2.apk
make packages/x86_64/scanelf-1.3.4-r2.apk
...
make packages/x86_64/logger-2.38.1-r0.apk
make packages/x86_64/glibc-locale-szl-2.36-r4.apk
make packages/x86_64/glibc-locale-pap-2.36-r4.apk
make packages/x86_64/glibc-locale-ky-2.36-r4.apk
make packages/x86_64/openjdk-11-jre-doc-11.0.17.8-r5.apk
```

For example, `sh -c "$(dag text)"`

...or, if we want to keep the Makefile around, we can generate the big block of `eval(call build-package`s:

```
$ dag text --type=makefile
$(eval $(call build-package,wolfi-baselayout,20221118-0))
$(eval $(call build-package,wget,1.21.3-2))
$(eval $(call build-package,xz,5.4.0-0))
$(eval $(call build-package,pax-utils,1.3.4-2))
$(eval $(call build-package,zlib,1.2.13-1))
...
$(eval $(call build-package,melange,0.2.0-0))
$(eval $(call build-package,kubectl,1.25.4-1))
$(eval $(call build-package,mailcap,2.1.53-0))
$(eval $(call build-package,grype,0.55.0-0))
$(eval $(call build-package,cosign,1.13.1-1))
```

As you can see in this example, this doesn't ensure the list is consistently sorted, only that roots of the dep graph are printed before leafs.

This change also adds understanding of `provides:` since some packages depend on "`ninja`" but that isn't actually packaged, just `provides`ed by `samurai`. We also need to take care not to reject `go` when it's `provides`ed by another package, like `go-stage0`, for example.